### PR TITLE
Map period interval codes to period names

### DIFF
--- a/src/Services/Period.php
+++ b/src/Services/Period.php
@@ -65,7 +65,7 @@ class Period
             'd' => 'Day',
             'w' => 'Week',
             'm' => 'Month',
-            'y' => 'Year',  
+            'y' => 'Year',
         ];
 
         $method = 'add'.$periodMapping[$this->interval].'s';

--- a/src/Services/Period.php
+++ b/src/Services/Period.php
@@ -65,7 +65,7 @@ class Period
             'd' => 'Day',
             'w' => 'Week',
             'm' => 'Month',
-            'y' => 'Year'  
+            'y' => 'Year',  
         ];
 
         $method = 'add'.$periodMapping[$this->interval].'s';

--- a/src/Services/Period.php
+++ b/src/Services/Period.php
@@ -61,7 +61,14 @@ class Period
             $this->period = $count;
         }
 
-        $method = 'add'.ucfirst($this->interval).'s';
+        $periodMapping = [
+            'd' => 'Day',
+            'w' => 'Week',
+            'm' => 'Month',
+            'y' => 'Year'  
+        ];
+
+        $method = 'add'.$periodMapping[$this->interval].'s';
         $start = clone $this->start;
         $this->end = $start->$method($this->period);
     }


### PR DESCRIPTION
the period intervals (d,w,m,y) are used to create a Carbon method to add the interval:

$test->addDays(3);

However the code generates: $test->addDs(3); and fails.